### PR TITLE
Split Farmer's Delight compat into two.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     modCompileOnly "maven.modrinth:farmers-delight-fabric:${farmers_delight_version}"
+    modCompileOnly "maven.modrinth:farmers-delight-refabricated:${farmers_delight_refabricated_version}"
 
     modRuntimeOnly "com.terraformersmc:modmenu:${mod_menu_version}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,5 @@ cardinal_components_version=5.2.2
 midnightlib_version=1.4.1-fabric
 fabric_version=0.91.0+1.20.1
 farmers_delight_version=1.4.3
+farmers_delight_refabricated_version=1.20.1-2.0.9
 mod_menu_version=7.2.2

--- a/src/main/java/moriyashiine/heartymeals/common/HeartyMeals.java
+++ b/src/main/java/moriyashiine/heartymeals/common/HeartyMeals.java
@@ -14,15 +14,17 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.util.Identifier;
 
+import java.util.Objects;
+
 public class HeartyMeals implements ModInitializer {
 	public static final String MOD_ID = "heartymeals";
 
-	public static boolean farmersDelightLoaded = false;
+	public static boolean farmersDelightLoaded = FabricLoader.getInstance().isModLoaded("farmersdelight");
+	public static boolean farmersDelightRefabricatedLoaded = FabricLoader.getInstance().getModContainer("farmersdelight").map(modContainer -> Objects.equals(modContainer.getMetadata().getVersion().getFriendlyString().split("-")[1].split("\\.")[0], "2")).orElse(false);
 
 	@Override
 	public void onInitialize() {
 		MidnightConfig.init(MOD_ID, ModConfig.class);
-		farmersDelightLoaded = FabricLoader.getInstance().isModLoaded("farmersdelight");
 		ModStatusEffects.init();
 		initEvents();
 	}

--- a/src/main/java/moriyashiine/heartymeals/common/ModMixinPlugin.java
+++ b/src/main/java/moriyashiine/heartymeals/common/ModMixinPlugin.java
@@ -24,8 +24,10 @@ public class ModMixinPlugin implements IMixinConfigPlugin {
 
 	@Override
 	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-		if (mixinClassName.contains("integration.farmersdelight")) {
-			return FabricLoader.getInstance().isModLoaded("farmersdelight");
+		if (mixinClassName.contains("integration.farmersdelight.fabric")) {
+			return HeartyMeals.farmersDelightLoaded && !HeartyMeals.farmersDelightRefabricatedLoaded;
+		} else if (mixinClassName.contains("integration.farmersdelight.refabricated")) {
+			return HeartyMeals.farmersDelightLoaded && HeartyMeals.farmersDelightRefabricatedLoaded;
 		}
 		return true;
 	}

--- a/src/main/java/moriyashiine/heartymeals/common/component/entity/FoodHealingComponent.java
+++ b/src/main/java/moriyashiine/heartymeals/common/component/entity/FoodHealingComponent.java
@@ -13,6 +13,7 @@ import moriyashiine.heartymeals.common.init.ModEntityComponents;
 import moriyashiine.heartymeals.common.init.ModStatusEffects;
 import moriyashiine.heartymeals.common.init.ModTags;
 import net.minecraft.block.BlockState;
+import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
@@ -24,6 +25,7 @@ import net.minecraft.state.property.Properties;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameRules;
+import vectorwing.farmersdelight.common.registry.ModEffects;
 
 public class FoodHealingComponent implements AutoSyncedComponent, CommonTickingComponent {
 	private final PlayerEntity obj;
@@ -150,13 +152,16 @@ public class FoodHealingComponent implements AutoSyncedComponent, CommonTickingC
 	}
 
 	private void tickNourishing() {
-		if (HeartyMeals.farmersDelightLoaded && obj.hasStatusEffect(EffectsRegistry.NOURISHMENT.get())) {
-			int duration = obj.getStatusEffect(EffectsRegistry.NOURISHMENT.get()).getDuration();
-			if (duration == StatusEffectInstance.INFINITE) {
-				duration = obj.age;
-			}
-			if (duration % 200 == 0) {
-				obj.heal(1);
+		if (HeartyMeals.farmersDelightLoaded) {
+			StatusEffect effect = HeartyMeals.farmersDelightRefabricatedLoaded ? ModEffects.NOURISHMENT.get() : EffectsRegistry.NOURISHMENT.get();
+			if (obj.hasStatusEffect(effect)) {
+				int duration = obj.getStatusEffect(effect).getDuration();
+				if (duration == StatusEffectInstance.INFINITE) {
+					duration = obj.age;
+				}
+				if (duration % 200 == 0) {
+					obj.heal(1);
+				}
 			}
 		}
 	}

--- a/src/main/java/moriyashiine/heartymeals/mixin/integration/farmersdelight/fabric/client/NourishmentHungerOverlayMixin.java
+++ b/src/main/java/moriyashiine/heartymeals/mixin/integration/farmersdelight/fabric/client/NourishmentHungerOverlayMixin.java
@@ -2,7 +2,7 @@
  * All Rights Reserved (c) MoriyaShiine
  */
 
-package moriyashiine.heartymeals.mixin.integration.farmersdelight.client;
+package moriyashiine.heartymeals.mixin.integration.farmersdelight.fabric.client;
 
 import com.nhoryzon.mc.farmersdelight.client.gui.NourishmentHungerOverlay;
 import net.minecraft.client.gui.DrawContext;

--- a/src/main/java/moriyashiine/heartymeals/mixin/integration/farmersdelight/refabricated/client/NourishmentHungerOverlayMixin.java
+++ b/src/main/java/moriyashiine/heartymeals/mixin/integration/farmersdelight/refabricated/client/NourishmentHungerOverlayMixin.java
@@ -1,0 +1,21 @@
+/*
+ * All Rights Reserved (c) MoriyaShiine
+ */
+
+package moriyashiine.heartymeals.mixin.integration.farmersdelight.refabricated.client;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.hud.InGameHud;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vectorwing.farmersdelight.client.gui.NourishmentHungerOverlay;
+
+@Mixin(value = NourishmentHungerOverlay.class, remap = false)
+public class NourishmentHungerOverlayMixin {
+	@Inject(method = "renderNourishmentOverlay", at = @At("HEAD"), cancellable = true)
+	private static void heartymeals$disableNourishingOverlay(InGameHud gui, DrawContext graphics, CallbackInfo ci) {
+		ci.cancel();
+	}
+}

--- a/src/main/resources/heartymeals.mixins.json
+++ b/src/main/resources/heartymeals.mixins.json
@@ -18,7 +18,8 @@
 	"client.AbstractInventoryScreenMixin",
 	"client.ClientPlayerEntityMixin",
 	"client.InGameHudMixin",
-	"integration.farmersdelight.client.NourishmentHungerOverlayMixin"
+	"integration.farmersdelight.fabric.client.NourishmentHungerOverlayMixin",
+  	"integration.farmersdelight.refabricated.client.NourishmentHungerOverlayMixin"
   ],
   "injectors": {
 	"defaultRequire": 1


### PR DESCRIPTION
I don't even play with this mod, but I figured I'd do this for the sake of it.

This PR implements Farmer's Delight Refabricated compat which will enable when Refabricated is detected, rather than Farmer's Delight Fabric.